### PR TITLE
Add context name via environment variable

### DIFF
--- a/1.4.1/assets/setenv.sh
+++ b/1.4.1/assets/setenv.sh
@@ -25,3 +25,11 @@ fi
 if [ "$LIBREPLAN_DBPASSWORD" ]; then
   sed -i "s/password=\"[^\"]*\"/password=\"$LIBREPLAN_DBPASSWORD\"/" $LIBREPLAN_XML
 fi
+
+if [ "$LIBREPLAN_CONTEXT" ]; then
+    mv $CATALINA_HOME/conf/Catalina/localhost/libreplan.xml \
+       $CATALINA_HOME/conf/Catalina/localhost/$LIBREPLAN_CONTEXT.xml
+
+    mv $CATALINA_HOME/webapps/libreplan.war \
+       $CATALINA_HOME/webapps/$LIBREPLAN_CONTEXT.war
+fi


### PR DESCRIPTION
Setting LIBREPLAN_CONTEXT allows to change the context name for tomcat deployment.
Note: Deployment files are still named libreplan.xml und libreplan.war, but will
be renamed after deployment.

Leaving LIBREPLAN_CONTEXT empty (or unset) results in the old behaviour.