### PR TITLE
Hacked files to be able to build a fresh container image

### DIFF
--- a/1.4.1/Dockerfile
+++ b/1.4.1/Dockerfile
@@ -1,18 +1,72 @@
-FROM tomcat:7
-MAINTAINER Philippe Poumaroux <poum@cpan.org>
+MAINTAINER "Jeroen Baten <jeroen@libreplan.dev>, Philippe Poumaroux <poum@cpan.org>"
+FROM tomcat:8.5-jdk8-temurin
 
-ENV LIBREPLAN_VERSION 1.4.1
+ARG LIBREPLAN_VERSION=1.4.1
+ARG PG_JDBC_VERSION=42.7.4
 
-ENV PG_JDBC_URL https://jdbc.postgresql.org/download/postgresql-9.4.1208.jre7.jar 
-ENV LIBREPLAN_WAR_URL http://downloads.sourceforge.net/project/libreplan/LibrePlan/libreplan_$LIBREPLAN_VERSION.war 
+ENV CATALINA_HOME=/usr/local/tomcat
+WORKDIR $CATALINA_HOME
 
-ADD "$PG_JDBC_URL" $CATALINA_HOME/lib/
+# Basic tools
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      curl xvfb cutycapt fonts-dejavu ca-certificates unzip zip \
+ && rm -rf /var/lib/apt/lists/*
+
+# JDBC driver
+RUN curl -fsSL -o $CATALINA_HOME/lib/postgresql-jdbc.jar \
+    "https://repo1.maven.org/maven2/org/postgresql/postgresql/${PG_JDBC_VERSION}/postgresql-${PG_JDBC_VERSION}.jar"
+
+# LibrePlan WAR download
+RUN curl -fL --retry 3 -o $CATALINA_HOME/webapps/libreplan.war \
+    "https://downloads.sourceforge.net/project/libreplan/LibrePlan/libreplan_${LIBREPLAN_VERSION}.war"
+#COPY ./libreplan.war $CATALINA_HOME/webapps/libreplan.war
+
+
+# --- Patch Spring 2.5.x Java-versiedetection in both jars ---
+# 1) unpack WAR
+RUN mkdir -p /tmp/war \
+ && unzip -q $CATALINA_HOME/webapps/libreplan.war -d /tmp/war
+
+# 2) Get JdkVersion.class out of a newer spring-core (3.0.7 is safe)
+RUN curl -fsSL -o /tmp/spring-core-3.0.7.RELEASE.jar \
+      https://repo1.maven.org/maven2/org/springframework/spring-core/3.0.7.RELEASE/spring-core-3.0.7.RELEASE.jar \
+ && mkdir -p /tmp/sc3 \
+ && (cd /tmp/sc3 && jar xf ../spring-core-3.0.7.RELEASE.jar org/springframework/core/JdkVersion.class)
+
+# 3) Patch spring-core-2.5.6.jar if present
+RUN if [ -f /tmp/war/WEB-INF/lib/spring-core-2.5.6.jar ]; then \
+       jar uf /tmp/war/WEB-INF/lib/spring-core-2.5.6.jar \
+         -C /tmp/sc3 org/springframework/core/JdkVersion.class ; \
+    fi
+
+# 4) Also patch the "fat" spring-2.5.6.jar, because the classloader can use that one too
+RUN if [ -f /tmp/war/WEB-INF/lib/spring-2.5.6.jar ]; then \
+       jar uf /tmp/war/WEB-INF/lib/spring-2.5.6.jar \
+         -C /tmp/sc3 org/springframework/core/JdkVersion.class ; \
+    fi
+
+# (optional) Throw away the fat-jar to prevent doubling:
+# RUN rm -f /tmp/war/WEB-INF/lib/spring-2.5.6.jar
+
+# 5) Pack the WAR back and in its place
+RUN (cd /tmp/war && zip -qr /tmp/libreplan_patched.war .) \
+ && mv /tmp/libreplan_patched.war $CATALINA_HOME/webapps/libreplan.war \
+ && rm -rf /tmp/war /tmp/sc3 /tmp/spring-core-3.0.7.RELEASE.jar
+
 COPY assets/libreplan.xml $CATALINA_HOME/conf/Catalina/localhost/
 COPY assets/catalina.policy $CATALINA_HOME/conf/
 COPY assets/setenv.sh $CATALINA_HOME/bin/
-ADD $LIBREPLAN_WAR_URL $CATALINA_HOME/webapps/libreplan.war
 
-RUN apt-get update && apt-get install -y \
-    cutycapt \
-    xvfb
+# (optione) somewat less aggresive JAR-scan for older WARs
+#ENV JAVA_OPTS="-Xms512m -Xmx1024m -Djava.awt.headless=true -Dtomcat.util.scan.StandardJarScanFilter.jarsToSkip=*.jar"
+ENV JAVA_OPTS="-Xms512m -Xmx1024m -Djava.awt.headless=true \
+  -Djava.version=1.6.0 \
+  -Djava.specification.version=1.6 \
+  -Djava.runtime.version=1.6.0"
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=40s --retries=5 \
+  CMD curl -fsS http://localhost:8080/libreplan/ || exit 1
 

--- a/1.4.1/docker-compose.yml
+++ b/1.4.1/docker-compose.yml
@@ -1,18 +1,43 @@
-db:
-    container_name: db
-    image: postgres:9.4
-    ports:
-        - "5432:5432"
-    environment:
-        POSTGRES_USER: libreplan
-        POSTGRES_PASSWORD: secret
-    volumes:
-        - ./sql:/docker-entrypoint-initdb.d
+version: "3.9"
 
-web:
-    container_name: web
-    image: libreplan/libreplan:latest
+services:
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: libreplan
+      POSTGRES_PASSWORD: libreplan
+      POSTGRES_DB: libreplan
+    volumes:
+      - libreplan_pgdata:/var/lib/postgresql/data
+      # Alle .sql/.sh in deze map worden automatisch uitgevoerd bij eerste init
+      - ./sql:/docker-entrypoint-initdb.d:ro
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U libreplan -d libreplan"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+    networks: [appnet]
+    restart: unless-stopped
+
+  libreplan:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        LIBREPLAN_VERSION: "1.4.1"
+        PG_JDBC_VERSION: "42.7.4"
+    image: libreplan/libreplan:oci-1.4.1
+    depends_on:
+      db:
+        condition: service_healthy
     ports:
-        - "8080:8080"
-    links:
-        - db
+      - "8080:8080"
+    networks: [appnet]
+    restart: unless-stopped
+
+networks:
+  appnet:
+
+volumes:
+  libreplan_pgdata:
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-![libreplan_logo](http://planet.libreplan.org/images/libreplan-logo.png)
+![libreplan_logo](https://avatars.githubusercontent.com/u/12512367?s=96&v=4)
 
-[LibrePlan](http://www.libreplan.com/) is a web project management application in which you can plan and manage projects.
+[LibrePlan](https://www.libreplan.dev/) is a web project management application in which you can plan and manage projects.
 
 ## LibrePlan docker images
 
@@ -9,6 +9,6 @@ This images are available on https://hub.docker.com/r/libreplan/libreplan.
 
 Currently, you'll find:
 
-- 1.4.1: Libreplan 1.4.1 image using a Postgresql database
-- 1.4.1-mysql: Libreplan 1.4.1 image using a MySQL database
+- 1.4.1: Up to date Libreplan 1.4.1 image using a Postgresql database
+- 1.4.1-mysql: Deprecated Libreplan 1.4.1 image using a MySQL database
 


### PR DESCRIPTION
The files contain a few dirty hacks, but it works and generates an OCI compliant container, using the original 1.4.1 libreplan.war file.